### PR TITLE
Harden W&B checkpoint deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.venv/
 dist/
 site/
 *.pyc

--- a/src/jlglove/cli/_app.py
+++ b/src/jlglove/cli/_app.py
@@ -1,5 +1,4 @@
 import os
-from datetime import timedelta
 from pathlib import Path
 
 import click
@@ -9,7 +8,6 @@ import torch
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import CSVLogger, WandbLogger
-from pytorch_lightning.strategies import DDPStrategy
 from rats import apps, cli, logs
 
 from jlglove import rep
@@ -73,7 +71,11 @@ class Application(apps.Container, cli.Container, apps.PluginMixin):
         eval_epoch = 10
         num_epochs = 50
         # TODO: not sure how to test this yet
-        ckpt_path = ".tmp/results/artifacts/model.ckpt" if checkpoint_name is not None else None
+        ckpt_path = (
+            str(Path(output_path) / "artifacts" / rep.CustomDataModule.CHECKPOINT_FILENAME)
+            if checkpoint_name is not None
+            else None
+        )
         train_partition_prop = 1.0
         batch_size = 1
         number_of_workers = 0
@@ -107,14 +109,7 @@ class Application(apps.Container, cli.Container, apps.PluginMixin):
             embedding_plotter,
             checkpoint_callback,
         ]
-
-        custom_timeout = timedelta(minutes=120)
-        DDPStrategy(
-            find_unused_parameters=False,
-            timeout=custom_timeout,
-            process_group_backend="nccl",
-            checkpoint_io=rep.CustomTorchCheckpointIO(),
-        )  # TODO NCCL fails when gpus > 2; gloo
+        checkpoint_io = rep.CustomTorchCheckpointIO()
 
         devices = torch.cuda.device_count()
         for i in range(devices):
@@ -137,6 +132,7 @@ class Application(apps.Container, cli.Container, apps.PluginMixin):
                 devices=devices,
                 accelerator="gpu",
                 # strategy=ddp_strategy, # TODO enable when using multiple GPUs
+                plugins=[checkpoint_io],
                 num_sanity_val_steps=0,
                 accumulate_grad_batches=4,
                 # precision="16-mixed",  # TODO: change to 16 for faster computation
@@ -148,6 +144,7 @@ class Application(apps.Container, cli.Container, apps.PluginMixin):
                 logger=torch_logger,
                 callbacks=custom_callbacks,
                 accelerator="cpu",
+                plugins=[checkpoint_io],
                 num_sanity_val_steps=0,
                 accumulate_grad_batches=4,
             )

--- a/src/jlglove/rep/_custom_callbacks.py
+++ b/src/jlglove/rep/_custom_callbacks.py
@@ -7,13 +7,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import umap
+import wandb
 from lightning_utilities.core.rank_zero import rank_zero_info
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.plugins.io import TorchCheckpointIO
 from pytorch_lightning.utilities import rank_zero_only
 from sklearn.manifold import TSNE
-
-import wandb
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,22 @@ class CustomTorchCheckpointIO(TorchCheckpointIO):
     _wandb_detected: bool
 
     def __init__(self) -> None:
+        super().__init__()
         self._wandb_detected = os.environ.get("WANDB_API_KEY") is not None
+
+    def load_checkpoint(self, path, map_location=None):  # type: ignore
+        checkpoint_path = Path(path).resolve()
+        with checkpoint_path.open("rb") as checkpoint_file:
+            checkpoint = torch.load(
+                checkpoint_file,
+                map_location=map_location,
+                weights_only=True,
+            )
+
+        if not isinstance(checkpoint, dict):
+            raise TypeError("checkpoint must contain a dictionary")
+
+        return checkpoint
 
     def save_checkpoint(self, checkpoint, path, storage_options=None):  # type: ignore
         # Create the directory if it doesn't exist
@@ -66,7 +80,7 @@ class CustomTorchCheckpointIO(TorchCheckpointIO):
         # Save the checkpoint locally in the specified path
         rank_zero_info(f"Saving checkpoint to {checkpoint_path}")
         with Path(checkpoint_path).open("wb") as f:
-            torch.save(checkpoint, f, pickle_protocol=4)  # Explicitly set pickle protocol to 4
+            torch.save(checkpoint, f)
         rank_zero_info(f"Checkpoint saved locally to {checkpoint_path}")
 
         # Log the checkpoint to W&B using artifacts

--- a/src/jlglove/rep/_custom_dataset.py
+++ b/src/jlglove/rep/_custom_dataset.py
@@ -7,16 +7,14 @@ from pathlib import Path
 import dask.dataframe as dd
 import pytorch_lightning as pl
 import torch
-
-# import wandb
-from torch.utils.data import DataLoader, Dataset
-
 import wandb
+from torch.utils.data import DataLoader, Dataset
 
 logger = logging.getLogger(__name__)
 
 
 class CustomDataModule(pl.LightningDataModule):
+    CHECKPOINT_FILENAME = "model.ckpt"
     _wandb_detected: bool
 
     def __init__(
@@ -35,7 +33,7 @@ class CustomDataModule(pl.LightningDataModule):
         self.ckpt_path = cktp_path
         self.local_training_data = None
         self.train_partition_prop = train_partition_prop
-        self.checkpoint_dir = checkpoint_dir + "/artifacts"
+        self.checkpoint_dir = Path(checkpoint_dir) / "artifacts"
         self._val_dataloader = None  # Caching validation dataloader
         self._test_dataloader = None  # Caching test dataloader
         self._wandb_detected = os.environ.get("WANDB_API_KEY") is not None
@@ -49,17 +47,30 @@ class CustomDataModule(pl.LightningDataModule):
             wandb.init(project="jl-glove")
             print("Downloading checkpoint from wandb...")
             artifact = wandb.use_artifact(self.ckpt_path, type="model")
-            artifact_dir = artifact.download(root=self.checkpoint_dir)
+            self.clear_directory(self.checkpoint_dir)
+            artifact_dir = Path(artifact.download(root=str(self.checkpoint_dir))).resolve()
             print("Saved Checkpoint files at: ", artifact_dir)
-            files = os.listdir(artifact_dir)  # noqa: PTH208
-            print("Files in the checkpoint directory:")
-            for file in files:
-                print(file)
-            self.local_ckpt_path = os.path.join(artifact_dir, files[-1])  # noqa: PTH118
+
+            checkpoint_files = [
+                checkpoint_file
+                for checkpoint_file in artifact_dir.rglob("*.ckpt")
+                if checkpoint_file.is_file() and not checkpoint_file.is_symlink()
+            ]
+            if len(checkpoint_files) != 1:
+                raise RuntimeError(
+                    f"expected one regular .ckpt file in artifact, found {len(checkpoint_files)}"
+                )
+
+            downloaded_checkpoint = checkpoint_files[0].resolve()
+            if not downloaded_checkpoint.is_relative_to(artifact_dir):
+                raise RuntimeError("checkpoint file resolves outside the artifact directory")
+
+            local_checkpoint = self.checkpoint_dir / self.CHECKPOINT_FILENAME
+            if downloaded_checkpoint != local_checkpoint.resolve():
+                shutil.copyfile(downloaded_checkpoint, local_checkpoint)
+
+            self.local_ckpt_path = str(local_checkpoint)
             print("Final checkpoint path: ", self.local_ckpt_path)
-            # Load the checkpoint file
-            checkpoint = torch.load(self.local_ckpt_path, weights_only=False)
-            print("Checkpoint Keys", checkpoint.keys())
 
     def clear_directory(self, directory):  # type: ignore
         if Path(directory).exists():

--- a/src/jlglove/rep/_glove_lightning_model.py
+++ b/src/jlglove/rep/_glove_lightning_model.py
@@ -74,7 +74,7 @@ class GloVeLightningModel(LightningModule):
         self.learning_rate = learning_rate
 
         # Store hyperparameters
-        self.save_hyperparameters()
+        self.save_hyperparameters(ignore=["bioid_df"])
 
     def weighting_func(self, x):  # type: ignore
         return self.b0 + self.b * (x**self.alpha)

--- a/src/jlglove/rep/_synthetic_data.py
+++ b/src/jlglove/rep/_synthetic_data.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import seaborn as sns
 from scipy.cluster.hierarchy import fcluster
@@ -73,7 +74,7 @@ class SyntheticDataGenerator:
 
         C_jl = jl_transform(C_sparse, n_components=100, donor_tcr=False)
         column_names = [f"JL_Col{i}" for i in range(C_jl.shape[1])]
-        final_embeddings_pd = pd.DataFrame(C_jl, columns=column_names)
+        final_embeddings_pd = pd.DataFrame(C_jl, columns=pd.Index(column_names))
         final_embeddings_pd.insert(0, "monotonic_index", final_embeddings_pd.index)
         final_embeddings_pd.insert(
             len(final_embeddings_pd.columns), "Total TCR Occurrence", tcr_total_occurrence
@@ -89,7 +90,9 @@ class SyntheticDataGenerator:
 
         return
 
-    def compute_total_tcr_occurrence(self, df: pd.DataFrame, bio_df: pd.DataFrame):
+    def compute_total_tcr_occurrence(
+        self, df: pd.DataFrame, bio_df: pd.DataFrame
+    ) -> npt.NDArray[np.float64]:
         # Assuming df and bio_df are Pandas DataFrames
         # Join the DataFrames on 'bioIdentity'
         seqs = pd.merge(df, bio_df, on="bioIdentity", how="inner")

--- a/test/jlglove_test/test_checkpoint_io.py
+++ b/test/jlglove_test/test_checkpoint_io.py
@@ -1,0 +1,59 @@
+import pickle
+from pathlib import Path
+
+import pytest
+import torch
+
+from jlglove.rep import CustomTorchCheckpointIO
+
+
+def _create_marker(marker_path: str) -> dict[str, object]:
+    Path(marker_path).touch()
+    return {}
+
+
+class _ExecutableCheckpoint:
+    def __init__(self, marker_path: Path) -> None:
+        self.marker_path = marker_path
+
+    def __reduce__(self):
+        return _create_marker, (str(self.marker_path),)
+
+
+def test_checkpoint_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint_path = tmp_path / "model.ckpt"
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    parameter = torch.nn.Parameter(torch.tensor([1.0, 2.0]))
+    optimizer = torch.optim.Adagrad([parameter])
+    checkpoint_io = CustomTorchCheckpointIO()
+    checkpoint_io.save_checkpoint(
+        {
+            "epoch": 2,
+            "state_dict": {"weight": torch.tensor([1.0, 2.0])},
+            "optimizer_states": [optimizer.state_dict()],
+        },
+        checkpoint_path,
+    )
+
+    checkpoint = checkpoint_io.load_checkpoint(checkpoint_path)
+
+    assert checkpoint["epoch"] == 2
+    torch.testing.assert_close(
+        checkpoint["state_dict"]["weight"],
+        torch.tensor([1.0, 2.0]),
+    )
+    assert len(checkpoint["optimizer_states"]) == 1
+
+
+def test_load_checkpoint_rejects_executable_pickle(tmp_path: Path) -> None:
+    checkpoint_path = tmp_path / "model.ckpt"
+    marker_path = tmp_path / "payload-executed"
+    torch.save(_ExecutableCheckpoint(marker_path), checkpoint_path)
+
+    with pytest.raises(pickle.UnpicklingError):
+        CustomTorchCheckpointIO().load_checkpoint(checkpoint_path)
+
+    assert not marker_path.exists()


### PR DESCRIPTION
## Summary
- enforce restricted `weights_only=True` loading through Lightning's active checkpoint I/O plugin
- validate downloaded W&B artifacts and deterministically place the single regular `.ckpt` file used for resume
- exclude the runtime DataFrame from serialized hyperparameters and add executable-pickle regression coverage
- ignore the repository-local `.venv` directory

## Testing
- `python -m pytest` (3 passed)
- `ruff check --no-fix` on changed Python files
- `ruff format --check` on changed Python files
- `pyright --pythonpath .venv/Scripts/python.exe` on changed Python files (0 errors)
- `python -m pip check`